### PR TITLE
Adjust domain forwarding payload to include domain UIDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -536,10 +536,16 @@ if uploaded:
                             logger.error(message)
                             continue
 
+                        combined_uids = [domain_uid_value]
+                        combined_uids.extend(
+                            uid
+                            for uid in unique_mailbox_uids
+                            if uid and uid not in combined_uids
+                        )
+
                         payload = {
-                            "domain_uid": domain_uid_value,
                             "forwarding_url": unique_forwarding[0],
-                            "uids": unique_mailbox_uids,
+                            "uids": combined_uids,
                         }
                         success, err, code = client.update_domain_forwarding(
                             domain_uid_value, payload


### PR DESCRIPTION
## Summary
- ensure the InboxKit client now merges domain UID values into the forwarding request payload while validating optional caller UIDs
- update the Streamlit app to include the domain UID in the forwarding payload `uids` list and drop the redundant `domain_uid` field

## Testing
- not run (requires InboxKit credentials)


------
https://chatgpt.com/codex/tasks/task_e_68cc7687553c832e9c42d3306f69da87